### PR TITLE
fix: notification always showing upon launch

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -141,8 +141,6 @@ export class Updater extends EventEmitter {
         }
       ]
     });
-
-    updateNotification.show();
   }
 
   /**


### PR DESCRIPTION
The update available notification would always show because of a line that wasn't removed after testing. This PR fixes this behavior.